### PR TITLE
RDKE-624 : Enabled network for ipk install task

### DIFF
--- a/classes/staging-ipk.bbclass
+++ b/classes/staging-ipk.bbclass
@@ -332,6 +332,8 @@ python(){
 }
 do_populate_ipk_sysroot[umask] = "022"
 
+do_populate_ipk_sysroot[network] = "1"
+
 deltask do_fetch
 deltask do_unpack
 deltask do_patch


### PR DESCRIPTION
As per the below commits in bitbake, it  can now restrict network access in various tasks based on "network" flag as implemented in: 
https://git.openembedded.org/bitbake/commit/?id=0746b6a2a32fec4c18bf1a52b1454ca4c04bf543  https://git.openembedded.org/bitbake/commit/?id=9d6341df611a1725090444f6f8eb0244aed08213  https://git.openembedded.org/openembedded-core/commit/?id=7ce1e88a3ad85bbb925bb9f7167dc0a5fd1c27f4


