### PR TITLE
RDKE-627 : Enable network for do_rootfs task

### DIFF
--- a/classes/custom-rootfs-creation.bbclass
+++ b/classes/custom-rootfs-creation.bbclass
@@ -210,3 +210,4 @@ python do_update_opkg_config () {
 
 do_rootfs[prefuncs] += "do_update_opkg_config"
 do_rootfs[depends] += "shadow-native:do_populate_sysroot"
+do_rootfs[network] = "1"


### PR DESCRIPTION
In RDKE, we are downloading the stack layer IPKs during the rootfs task, which requires the network to be enabled.