### PR TITLE
RDKE-819 : Enabling sstate support for staging ipk

### DIFF
--- a/recipes-core/staging-ipk-pkgs.bb
+++ b/recipes-core/staging-ipk-pkgs.bb
@@ -8,9 +8,5 @@ inherit staging-ipk
 # stripped, we should skip the strip checking.
 INSANE_SKIP:${PN} += " already-stripped "
 
-# Disabling sstate, as this recipe needs to
-# execute to install the IPKs.
-SSTATE_SKIP_CREATION = "1"
-
 #Enable nativesdk support for the recipe.
 BBCLASSEXTEND = "nativesdk"


### PR DESCRIPTION
Currently, IPK installs and creates a new staging common each time. The new implementation will create a new staging only if there is an index mismatch.