### PR TITLE
RDKE-832 : Fix intermittent recipe parsing failure

### DIFF
--- a/classes/base-deps-resolver.bbclass
+++ b/classes/base-deps-resolver.bbclass
@@ -825,7 +825,7 @@ def check_deps_ipk_mode(d, dep_bpkg, rrecommends = False, version = None):
     prefix = d.getVar('MLPREFIX') or ""
     ipkmode = False
     if not dep_bpkg:
-        return ipkmode
+        return (ipkmode, version_mismatch, same_arch)
     # Check dep package is in IPK mode
     if prefix and dep_bpkg.startswith(prefix):
         src_dep_bpkg = dep_bpkg[len(prefix):]


### PR DESCRIPTION
Fixing below build failure
  File "/home/srr02/TOOLCHAIN_CREATION/rdkcentral/rdke/common/meta-stack-layering-support/classes/base-deps-resolver.bbclass", line 909, in get_inter_layer_pkgs(e=<bb.event.RecipeParsed object at 0x7f6879d3b880>, pkg='freediameter', deps='pkgconfig-native cmake-native virtual/aarch64-oe-linux-gcc virtual/aarch64-oe-linux-compilerlibs virtual/libc flex bison cmake-native libgcrypt gnutls libidn lksctp-tools virtual/kernel bison-native  pseudo-native opkg-native  ninja-native systemd-systemctl-native', rrecommends=False, skip_depends=False):
             if preferred_provider is not None:
    >            (ipk_mode, version_check, arch_check) = check_deps_ipk_mode(e.data, preferred_provider, rrecommends, None)
                 if ipk_mode:
TypeError: cannot unpack non-iterable bool object