### PR TITLE
RDKE-680 : Exclude -dev ipk from rdepends field for .so dependencies

### DIFF
--- a/classes/base-deps-resolver.bbclass
+++ b/classes/base-deps-resolver.bbclass
@@ -1105,6 +1105,8 @@ def update_rdeps_shlib(d,pkg):
             shlib_skip = d.getVar('SHLIBSKIPLIST_%s'%pkg).split(" ")
             for shlib in shlib_skip:
                 ipk = get_rdeps_provider_ipk(d,shlib)
+                if ipk.endswith("-dev"):
+                    continue
                 if ipk not in ipks and ipk != " ":
                     ipks.append(ipk)
                 if ipk != " ":


### PR DESCRIPTION
Some packages are linking with .so files instead of .so.version. In this case, Yocto skips checking for missing dependencies in the -dev package. However, in the layered framework, if the shared libraries are not provided by any recipe packages, it checks the IPKs and adds the IPKs that provide those libraries as RDEPENDS. We need to skip the dependency if it is provided by a -dev IPK package.