### PR TITLE
RDKOSS-894: pass -f to opkg-make-index to preserve user-defined fields

### DIFF
--- a/classes/base-deps-resolver.bbclass
+++ b/classes/base-deps-resolver.bbclass
@@ -1771,7 +1771,7 @@ python feed_index_creation () {
         if not os.path.exists(pkgs_file):
             open(pkgs_file, "w").close()
 
-        cmds.add('%s --checksum md5 --checksum sha256 -r %s -p %s -m %s' %
+        cmds.add('%s --checksum md5 --checksum sha256 -f -r %s -p %s -m %s' %
                      (opkg_index_cmd, pkgs_file, pkgs_file, pkgs_dir))
 
     if len(cmds) == 0:


### PR DESCRIPTION
Reason for change:
opkg-make-index strips non-standard IPK control fields (e.g. Source-URI, Source-Rev written by a custom bbclass) from the Packages index unless the -f (Include user-defined fields) flag is supplied.  Without -f every indexing run logs "Lost field: <fieldname>" for every custom field in every package and the fields are absent from the resulting Packages file, making them unavailable to downstream consumers.
It is simple: silent no-op when no user fields are present, preserving when they are. 

