### PR TITLE
RDKOSS-961: Changes to support Hash Equivalence

### DIFF
--- a/classes/base-deps-resolver.bbclass
+++ b/classes/base-deps-resolver.bbclass
@@ -19,7 +19,7 @@ SSTATE_MANFILEPREFIX_NATIVE_FILTER = "${SSTATE_MANIFESTS}/manifest-"
 SYSROOT_PREBUILT_DESTDIR = "${WORKDIR}/sysroot-prebuilt-destdir"
 PREBUILTDEPLOYDIR = "${COMPONENTS_DIR}/${PACKAGE_ARCH}"
 
-PSEUDO_IGNORE_PATHS .= ",${IPK_PKGDATA_RUNTIME_DIR},${IPK_PKGDATA_DIR}"
+PSEUDO_IGNORE_PATHS .= ",${IPK_PKGDATA_DIR}"
 
 do_install_ipk_recipe_sysroot[depends] += "opkg-native:do_populate_sysroot"
 


### PR DESCRIPTION
Reason for change : To avoid file permission change thus avoiding sstate sig validation error
Test procuedure : Build and verify with Hash equivalence enabled
Risk: Low